### PR TITLE
Server data filling rework and minor tweaks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("com.google.code.gson:gson:2.10.1")
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
I've made some changes, primarily to fix the server data filling issue, caused by the different naming schemes between betacraft's server index and mojang's version's index.

Some notable changes:
- updated gson to 2.10.1
- populate server indexes before starting to modify the manifests, we can avoid looping through the entire index each edit like that
- we fetch the latest server version compatible with the client (note: it include snapshots too)

Some notes:
- gson seems to REALLY hate when we are using parallelized streams (random deserialization exceptions), so i've took the initiative to remove it
- there are some hardcoded fixes to ensure subversions (ex: a1.2.3a and a1.2.3b) are correctly edited
- i am not well familliar with kotlin, so it's probably very poorly implemented

i know this is not really useful for babric which is focused on b1.7.3 but it would be really cool if this could get reviewed and pushed, thanks in advance!